### PR TITLE
Adds iOS ASWebAuthenticationSession as a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ If you want to use this module in Titanium SDK 6.x, please use the [this version
 
 * `createAuthenticationSession(arguments)`
     * `url` (String)
-    * `scheme` (String) 
+    * `scheme` (String)
+
+#### Events
+
+* `callback` -> `success` (Boolean), `callbackURL` (String)
+
+### `ASWebAuthenticationSession` (iOS 12+ only)
+
+#### Methods
+
+* `createASWebAuthenticationSession(arguments)`
+    * `url` (String)
+    * `scheme` (String)
 
 #### Events
 

--- a/ios/Classes/TiWebdialogASWebAuthenticationSessionProxy.h
+++ b/ios/Classes/TiWebdialogASWebAuthenticationSessionProxy.h
@@ -1,0 +1,32 @@
+/**
+ * Ti.WebDialog
+ *
+ * Copyright (c) 2009-present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#if IS_IOS_12
+
+#import "TiProxy.h"
+// #import <SafariServices/SafariServices.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+// @interface TiWebdialogAuthenticationSessionProxy : TiProxy {
+//   SFAuthenticationSession *_authSession;
+// }
+@interface TiWebdialogASWebAuthenticationSessionProxy : TiProxy {
+  ASWebAuthenticationSession *_authSession;
+}
+
+#pragma mark Public API's
+
+- (void)start:(id)unused;
+
+- (void)cancel:(id)unused;
+
+- (NSNumber *)isSupported:(id)unused;
+
+@end
+
+#endif

--- a/ios/Classes/TiWebdialogASWebAuthenticationSessionProxy.m
+++ b/ios/Classes/TiWebdialogASWebAuthenticationSessionProxy.m
@@ -1,0 +1,63 @@
+/**
+ * Ti.WebDialog
+ *
+ * Copyright (c) 2009-present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#if IS_IOS_12
+
+#import "TiWebdialogASWebAuthenticationSessionProxy.h"
+#import "TiUtils.h"
+
+@implementation TiWebdialogASWebAuthenticationSessionProxy
+
+- (ASWebAuthenticationSession *)authSession
+{
+  if (_authSession == nil) {
+    NSString *url = [TiUtils stringValue:[self valueForKey:@"url"]];
+    NSString *scheme = [TiUtils stringValue:[self valueForKey:@"scheme"]];
+
+    _authSession = [[ASWebAuthenticationSession alloc] initWithURL:[TiUtils toURL:url proxy:self]
+                                              callbackURLScheme:[TiUtils stringValue:scheme]
+                                              completionHandler:^(NSURL *callbackURL, NSError *error) {
+                                                NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                  @"success" : NUMBOOL(error == nil)
+                                                }];
+
+                                                if (error != nil) {
+                                                  [event setObject:[error localizedDescription] forKey:@"error"];
+                                                } else {
+                                                  [event setObject:[callbackURL absoluteString] forKey:@"callbackURL"];
+                                                }
+
+                                                if ([self _hasListeners:@"callback"]) {
+                                                  [self fireEvent:@"callback" withObject:event];
+                                                }
+                                              }];
+  }
+
+  return _authSession;
+}
+
+#pragma mark Public API's
+
+- (void)start:(id)unused
+{
+  [[self authSession] start];
+}
+
+- (void)cancel:(id)unused
+{
+  [[self authSession] cancel];
+}
+
+- (NSNumber *)isSupported:(id)unused
+{
+  return NUMBOOL([TiUtils isIOSVersionOrGreater:@"12.0"]);
+}
+
+@end
+
+#endif

--- a/ios/TiWebdialog_Prefix.pch
+++ b/ios/TiWebdialog_Prefix.pch
@@ -9,3 +9,10 @@
 #else
 #define IS_IOS_11 false
 #endif
+
+// iOS 12+ API's
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
+#define IS_IOS_12 true
+#else
+#define IS_IOS_12 false
+#endif

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.1.0
+version: 1.1.1
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: titanium-web-dialog

--- a/ios/module.xcconfig
+++ b/ios/module.xcconfig
@@ -1,1 +1,1 @@
-OTHER_LDFLAGS=$(inherited) -weak_framework SafariServices
+OTHER_LDFLAGS=$(inherited) -weak_framework SafariServices -weak_framework AuthenticationServices

--- a/ios/titanium-web-dialog.xcodeproj/project.pbxproj
+++ b/ios/titanium-web-dialog.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
 		DB529B8A1FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DB529B881FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.h */; };
 		DB529B8B1FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DB529B891FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.m */; };
+		E8A2BE8F2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = E8A2BE8D2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.m */; };
+		E8A2BE902268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = E8A2BE8E2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.h */; };
+		E8A2BE922268BBBF00109490 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A2BE912268BBBF00109490 /* AuthenticationServices.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +56,9 @@
 		D2AAC07E0554694100DB518D /* libti.webdialog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libti.webdialog.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB529B881FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TiWebdialogAuthenticationSessionProxy.h; path = Classes/TiWebdialogAuthenticationSessionProxy.h; sourceTree = "<group>"; };
 		DB529B891FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TiWebdialogAuthenticationSessionProxy.m; path = Classes/TiWebdialogAuthenticationSessionProxy.m; sourceTree = "<group>"; };
+		E8A2BE8D2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TiWebdialogASWebAuthenticationSessionProxy.m; path = Classes/TiWebdialogASWebAuthenticationSessionProxy.m; sourceTree = "<group>"; };
+		E8A2BE8E2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TiWebdialogASWebAuthenticationSessionProxy.h; path = Classes/TiWebdialogASWebAuthenticationSessionProxy.h; sourceTree = "<group>"; };
+		E8A2BE912268BBBF00109490 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E8A2BE922268BBBF00109490 /* AuthenticationServices.framework in Frameworks */,
 				AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -89,6 +96,7 @@
 		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E8A2BE912268BBBF00109490 /* AuthenticationServices.framework */,
 				AACBBE490F95108600F1A2B1 /* Foundation.framework */,
 			);
 			name = Frameworks;
@@ -103,6 +111,8 @@
 				24DD6CF81134B3F500162E58 /* TiWebdialogModule.m */,
 				DB529B881FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.h */,
 				DB529B891FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.m */,
+				E8A2BE8E2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.h */,
+				E8A2BE8D2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.m */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -126,6 +136,7 @@
 				AA747D9F0F9514B9006C5449 /* TiWebdialog_Prefix.pch in Headers */,
 				24DD6CF91134B3F500162E58 /* TiWebdialogModule.h in Headers */,
 				DB529B8A1FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.h in Headers */,
+				E8A2BE902268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.h in Headers */,
 				24DE9E1111C5FE74003F90F6 /* TiWebdialogModuleAssets.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -202,6 +213,7 @@
 			files = (
 				DB529B8B1FD5589E003A23FD /* TiWebdialogAuthenticationSessionProxy.m in Sources */,
 				24DD6CFA1134B3F500162E58 /* TiWebdialogModule.m in Sources */,
+				E8A2BE8F2268B4F200109490 /* TiWebdialogASWebAuthenticationSessionProxy.m in Sources */,
 				24DE9E1211C5FE74003F90F6 /* TiWebdialogModuleAssets.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
That's my attempt on adding support for **ASWebAuthenticationSession** on iOS and keeping the SFAuthenticationSession working at the same time.
In order to do so I had to make a secondary proxy for that so the user can decide what to call: `SFAuthenticationSession` or `ASWebAuthenticationSession`
Not sure if that's the best approach but we can discuss that if not. If it is fine, I can also push the .zip built file as a release in the repo =)