### PR TITLE
feat(android): support passing intent flags

### DIFF
--- a/android/src/ti/webdialog/Params.java
+++ b/android/src/ti/webdialog/Params.java
@@ -10,4 +10,5 @@ public class Params
 	public static final String ENABLE_SHARING = "enableSharing";
 	public static final String CLOSE_ICON = "closeIcon";
 	public static final String BAR_COLLAPSING_ENABLED = "barCollapsingEnabled";
+	public static final String INTENT_FLAGS = "intentFlags";
 }

--- a/android/src/ti/webdialog/TitaniumWebDialogModule.java
+++ b/android/src/ti/webdialog/TitaniumWebDialogModule.java
@@ -93,6 +93,10 @@ public class TitaniumWebDialogModule extends KrollModule
 
 		CustomTabsIntent tabIntent = builder.build();
 
+		if (options.containsKeyAndNotNull(Params.INTENT_FLAGS)) {
+			tabIntent.intent.addFlags(options.getInt(Params.INTENT_FLAGS));
+		}
+
 		for (String s : customTabBrowsers) {
 			tabIntent.intent.setPackage(s);
 		}

--- a/apidoc/WebDialog.yml
+++ b/apidoc/WebDialog.yml
@@ -149,7 +149,7 @@ events:
                
 ---
 name: WebDialogOpenParams
-summary: Parmaters used in the <Modules.WebDialog.open> method
+summary: Parameters used in the <Modules.WebDialog.open> method
 properties:
   - name: url
     summary: The URL to be opened.
@@ -197,3 +197,10 @@ properties:
     default: true
     type: Boolean
     platforms: [iphone, ipad, android]
+
+  - name: intentFlags
+    summary: Intent flags to be used for the Chrome Custom Tab, specified as a Bitwise-OR
+    optional: true
+    type: Number
+    constants: Titanium.Android.FLAG_*
+    platform: [android]


### PR DESCRIPTION
Ti.Android.FLAG_* constants can be used to add intent flags to the Chrome Custom Tab allowing a user to control behaviour such as closing after a redirect has finished with intentFlags: Ti.Android.FLAG_ACTIVITY_NO_HISTORY | Ti.Android.FLAG_ACTIVITY_NEW_TASK