### PR TITLE
feat(ios): macOS support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ library 'pipeline-library'
 def isMaster = env.BRANCH_NAME.equals('master')
 
 buildModule {
-	sdkVersion = '9.0.0.v20200127103011'
+	sdkVersion = '9.2.0.v20200911073932' // use a master build with ARM64 sim, and macOS support
 	npmPublish = isMaster // By default it'll do github release on master anyways too
-	iosLabels = 'osx && xcode-11'
+	iosLabels = 'osx && xcode-12'
 }

--- a/apidoc/WebDialog.yml
+++ b/apidoc/WebDialog.yml
@@ -6,7 +6,6 @@ since: "7.1.0"
 extends: Titanium.Module
 osver: { ios: { min: "9.0" }, android: { min: "4.1" } }
 description: |
-    
     The WebDialog module provides Titanium access to the native `SFSafariViewController` (iOS) and `ChromeTabs` (Android). 
     This enables you to deliver interactive web content in your app just like the built-in browser, including the native UI elements already 
     familiar to your users.

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.2.0
+version: 2.0.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: titanium-web-dialog
@@ -15,4 +15,4 @@ name: titanium-web-dialog
 moduleid: ti.webdialog
 guid: 1f19cce1-0ad7-4e25-ab3b-0666f54a0a49
 platform: iphone
-minsdk: 7.0.0
+minsdk: 9.2.0

--- a/ios/titanium.xcconfig
+++ b/ios/titanium.xcconfig
@@ -4,13 +4,13 @@
 // OF YOUR TITANIUM SDK YOU'RE BUILDING FOR
 //
 //
-TITANIUM_SDK_VERSION = 9.0.0.GA
+TITANIUM_SDK_VERSION = 9.2.0.GA
 
 //
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
 TITANIUM_SDK = /Users/$(USER)/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
 HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
-FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium-sdk/ti.webdialog",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium-sdk/ti.webdialog",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Use the native `SFSafariViewController` (iOS) and `Chrome Pages` (Android) within Axway Titanium.",
   "scripts": {
     "commit": "git-cz",

--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -12,7 +12,7 @@ module.exports = config => {
 			'karma-*'
 		],
 		titanium: {
-			sdkVersion: config.sdkVersion || '9.0.0.GA'
+			sdkVersion: config.sdkVersion || '9.2.0.GA'
 		},
 		customLaunchers: {
 			android: {


### PR DESCRIPTION
Needs to be built with SDK from master (Relied on changes from appcelerator/titanium_mobile#12033 to support xcframeworks and macOS)

This is PR  gets the module building with the SDK that enables macOS support and builds as an xcframework (to support arm64 sims when Apple Silicon computers ship!). I've tested locally (and pushed fixes to the SDK) to get this working. I was able to test an iPhone sim and macOS catalyst locally.

The most relevant change here is to the `iOS/titanium.xcconfig` using a recursive path for `FRAMEWORK_SEARCH_PATHS`. Because the SDK packages TitaniumKit as an XCFramework, the underlying framework folders are underneath each os/arch combo parent.

**NOTE:** In the example app, when I clicked the link top open a web dialog, it opened the URL in a new tab in my already launched Safari (desktop app) on macOS. As a result, it appears a number of the properties (`tintColor`, `barColor`) seem unused on macOS.

Related:
- appcelerator-modules/titanium-identity#60
- appcelerator-modules/ti.map#309
- appcelerator-modules/titanium-apple-sign-in#16