### PR TITLE
fix(ios): excluded fragment delimiter from encoding

### DIFF
--- a/ios/Classes/TiWebdialogModule.m
+++ b/ios/Classes/TiWebdialogModule.m
@@ -58,7 +58,9 @@
 - (SFSafariViewController *)safariController:(NSString *)url withEntersReaderIfAvailable:(BOOL)entersReaderIfAvailable andBarCollapsingEnabled:(BOOL)barCollapsingEnabled
 {
   if (_safariController == nil) {
-    NSString *encodedURL = [url stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
+    NSMutableCharacterSet *allowedCharacters = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [allowedCharacters addCharactersInString:@"#"]; // https://github.com/tidev/titanium-web-dialog/issues/329
+    NSString *encodedURL = [url stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
     NSURL *safariURL = [NSURL URLWithString:encodedURL];
 
     SFSafariViewControllerConfiguration *config = [[SFSafariViewControllerConfiguration alloc] init];

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.0.0
+version: 4.0.1
 apiversion: 2
 architectures: arm64 x86_64
 description: titanium-web-dialog


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-web-dialog/issues/329.

**Description:**

- `SFSafariViewController` has a problem with encoded `#` as fragment delimiter, which was introduced in module version [3.0.2](https://github.com/tidev/titanium-web-dialog/releases/tag/v3.0.2-ios)
- excluded `#` from encoding

**Example:**

```
const webDialog = require('ti.webdialog');
const win = Ti.UI.createWindow();

win.open();
webDialog.open({
   url: "https://titaniumsdk.com/api/modules/webdialog.html#methods_open",
});
```